### PR TITLE
Check whether each operation has 'op' in it

### DIFF
--- a/dex/dex.py
+++ b/dex/dex.py
@@ -520,6 +520,10 @@ class ProfileParser:
     def parse(self, input):
         """Passes input to each QueryLineHandler in use"""
         raw_query = {}
+
+        if 'op' not in input:
+            return None
+
         if input['op'] == 'insert':
             return None
         elif input['op'] == 'query':


### PR DESCRIPTION
Profile might contain operation in which 'op' element is absent. For
these cases accessing 'op' element as `input['op']` fails.

Example: (tested on Mongodb 2.0.6)

``` python
{u'info': u'query admin.$cmd ntoreturn:1 command: { listDatabases: 1.0 } reslen:836 bytes:820 1ms', u'millis': 1.0, u'ts': datetime.datetime(2011, 10, 22, 10, 26, 35, 405000)}

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "dex/dex.py", line 148, in analyze_profile
    out)
  File "dex/dex.py", line 93, in _process_query
    raw_query = parser.parse(input)
  File "dex/dex.py", line 524, in parse
    if input['op'] == 'insert':
KeyError: 'op'
```

To avoid this error check whether operation has 'op' field else return None.
